### PR TITLE
2020-02-11 notes

### DIFF
--- a/hdtt2020.sty
+++ b/hdtt2020.sty
@@ -118,7 +118,7 @@
 \NewDocumentCommand{\lam}{gog}{\IfValueTF{#1}{\IfValueTF{#2}{\lambda\parens{#1:#2}.#3}{\lambda#1.#3}}{\lambda}}
 \NewDocumentCommand{\app}{mm}{#1\;#2}
 \NewDocumentCommand{\nattype}{}{\varmathbb{N}}
-\NewDocumentCommand{\idtype}{ggg}{\IfValueTF{#3}{\mathtt{Id}_{#1}\parens{#2; #3}}{\IfValueTF{#1}{\mathtt{Id}\parens{#1; #2}{\mathtt{Id}}}}}
+\NewDocumentCommand{\idtype}{ggg}{\IfValueTF{#3}{\mathtt{Id}_{#1}\parens{#2; #3}}{\IfValueTF{#1}{\mathtt{Id}\parens{#1; #2}}{\mathtt{Id}}}}
 \NewDocumentCommand{\idrefl}{g}{\mathtt{refl}\IfValueT{#1}{\parens{#1}}}
 \NewDocumentCommand{\idJ}{ooooggg}{%
   \mathtt{J}%

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -156,7 +156,7 @@ We can also extend identification types with UIP, or alternatively Axiom K. Axio
 Each type $A$ has the structure of an $\infty$-groupoid induced by the identification types constructed from $A$ (recall that a groupoid is a category whose morphisms are all isomorphisms, and an $\infty$-groupoid is an ``infinite-dimensional generalization'' of a groupoid).
 \end{theorem}
 
-This theorem discovers a new connection between type theory and higher category theory. Note, however, that the theorem does not hold if identification types are substituted by equality types or reflection-free equality types introduced below; this is one of the main reasons why identification types are the most popular choice among types on equality.
+This theorem discovers a new connection between type theory and higher category theory. Note, however, that the theorem is much less interesting if identification types are substituted by the equality types or reflection-free equality types introduced above, since all higher-dimensional structure is trivial; this is one of the main reasons why identification types are the most popular choice among types on equality.
 
 The homotopy-theoretic point of view on type theory, which creates the currently active field of homotopy type theory, interprets:
 

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -129,6 +129,12 @@ Note that by the substitutional nature of judgmental equality the converse holds
 
 In this sense, equality types and judgmental equality are equivalent. Formally, the rules of equality types consist of those of identification types and the equality reflection rule.
 
+Note: One implementation of equality types additionally has the following uniqueness rule:
+\begin{prooftree*}
+	\hypo{\oftype{p}{\mathtt{Eq}_A\parens{M; N}}}
+	\infer1[$\mathtt{Eq}$-uniq]{\eqterm{p}{\idrefl}{\mathtt{Eq}_A\parens{M; N}}}
+\end{prooftree*}
+
 \subsection{Reflection-Free Equality Types}
 A variant of equality types is reflection-free equality types \cite{sterling_et_al:LIPIcs:2019:10538}. They are intended to obtain the best parts of identification types and (ordinary) equality types. Reflection-free equality types are obtained from equality types by replacing the equality reflection rule by the following strict principle of uniqueness of identity proofs (UIP):
 

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -29,17 +29,15 @@ There are several different specific notions of equality used in papers. Some ef
 A natural idea for implementing equality is to specify pairs of terms to be equated directly by judgments, which convey no information other than the equated terms (and, in the type theories we're studying in this course, their type). The equality judgment is written like:
 
 \[
-	\eqterm{\Gamma}{M}{N}{A}
+	\eqtype{\Gamma}{A}{B}
 \]
 
 Judgmental equality is \emph{silent and substitutional}, in the sense that:
 
 \begin{prooftree*}
 	\hypo{\oftype{\Gamma}{M}{A}}
-	\ellipsis{}{\hspace{0.75in}}
-	\hypo{\eqterm{\Gamma}{M}{N}{A}}
-	\ellipsis{}{\hspace{0.75in}}
-	\infer2{\oftype{\Gamma}{N}{A}}
+	\hypo{\eqtype{\Gamma}{A}{B}}
+	\infer2{\oftype{\Gamma}{M}{B}}
 \end{prooftree*}
 
 This is a useful property if one wants to prove subject reduction (aka type preservation).
@@ -111,9 +109,6 @@ There is also an alternative formulation of $\idtype$-elim and $\idtype$-comp:
 	\infer2[$\idtype$-comp$^{M=}$]{\eqterm{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; \idrefl{M}}}{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
 \end{prooftree*}
 
-% NOTE(remexre): The below \cite doesn't render on tectonic; I haven't been
-% able to get it working with pdflatex+biber either, but I'm not enough of
-% a TeX wizard to know what the issue is.
 This formulation is often easier to use in practice, but is equivalent to the one initially presented; see section 1.12.1 of \cite{hott-as:book} for details.
 
 \subsection{(Usual) Equality Types}
@@ -135,14 +130,8 @@ Note that by the substitutional nature of judgmental equality the converse holds
 In this sense, equality types and judgmental equality are equivalent. Formally, the rules of equality types consist of those of identification types and the equality reflection rule.
 
 \subsection{Reflection-Free Equality Types}
-A variant of equality types is reflection-free equality types. They are intended to obtain the best parts of identification types and (ordinary) equality types. Reflection-free equality types are obtained from equality types by replacing the equality reflection rule by the following strict principle of uniqueness of identity proofs (UIP):
+A variant of equality types is reflection-free equality types \cite{sterling_et_al:LIPIcs:2019:10538}. They are intended to obtain the best parts of identification types and (ordinary) equality types. Reflection-free equality types are obtained from equality types by replacing the equality reflection rule by the following strict principle of uniqueness of identity proofs (UIP):
 
-% \begin{mathpar}
-% \AxiomC{$\Gamma \vdash P : \mathsf{Eq}_A(M, N)$}
-% \AxiomC{$\Gamma \vdash Q : \mathsf{Eq}_A(M, N)$}
-% \BinaryInfC{$\Gamma \vdash P \equiv Q : \mathsf{Eq}_A(M, N)$}
-% \DisplayProof
-% \end{mathpar}
 \begin{prooftree*}
 	\hypo{\oftype{\ctx}{p}{\mathtt{Eq}_A\parens{M; N}}}
 	\hypo{\oftype{\ctx}{q}{\mathtt{Eq}_A\parens{M; N}}}
@@ -158,10 +147,10 @@ Alternatively, we may employ Axiom K, which is equivalent to UIP in the sense th
 
 We can also extend identification types with UIP; again see \cite{hott-as:book} for the details. 
 
-\section{The $\omega$-Groupoid Structure of Types}
+\section{The $\infty$-Groupoid Structure of Types}
 
 \begin{theorem}
-Each type $A$ has the structure of an $\omega$-groupoid induced by the identification types constructed from $A$ (recall that a groupoid is a category whose morphisms are all isomorphisms, and an $\omega$-groupoid is an ``infinite-dimensional generalization'' of a groupoid).
+Each type $A$ has the structure of an $\infty$-groupoid induced by the identification types constructed from $A$ (recall that a groupoid is a category whose morphisms are all isomorphisms, and an $\infty$-groupoid is an ``infinite-dimensional generalization'' of a groupoid).
 \end{theorem}
 
 This theorem discovers a new connection between type theory and higher category theory. Note, however, that the theorem does not hold if identification types are substituted by equality types or reflection-free equality types introduced below; this is one of the main reasons why identification types are the most popular choice among types on equality.

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -1,0 +1,185 @@
+\documentclass[11pt]{article}
+\usepackage{hdtt2020}
+\usepackage{newpxmath}
+\usepackage{newpxtext}
+
+\title{CSCI 8980 Higher-Dimensional Type Theory\\ Lecture Notes}
+\author{Norihiro Yamada, Nathan Ringo}
+\date{February 11, 2020}
+
+\begin{document}
+
+\maketitle
+
+\section{Extensionality and Intensionality}
+Two commonly used but insufficiently precise terms used to dicuss notions of equality are ``extensional equality'' and ``intensional equality.''
+
+An extensional notion of equality treats two objects that have observationally equivalent properties as being equal. For example, one might consider the sets $A = \left(\{\textrm{single-digit primes}\} \cup \{6\}\right)$ to be extensionally equal to $B = \left(\{\textrm{single-digit numbers}\} - \{x^2 \mid x \in \mathbb{N}\}\right)$, since $\forall n. \left(n \in A \iff n \in B\right)$. Similarly, $x + y$ and $y + x$ would be considered equal, since their results are the same for any $x$ and $y$.
+
+Contrastingly, an intensional notion of equality only considers objects to be equal if their definitions are equal. Often the equality of definitions is checked syntactically; i.e., two definitions are equivalent if and only if they are literally textually identical. With such a definition, neither $A$ and $B$ nor $x + y$ and $y + x$ would \textbf{not} be considered equal,
+
+Theories built on the lambda calculus that claim to use intensional equality will often define this syntactic equality to be after $\alpha$, $\beta$, and $\eta$-normalization. This makes the terms $\lam{x}[\nattype]{x}$ and $\app{\parens{\lam{p}[\funtype{\nattype}{\nattype}]{p}}}{\parens{\lam{q}[\nattype]{q}}}$ equal, and is often useful, since the evaluation rules don't need to be manipulated by the user.
+
+\section{Equalities}
+
+There are several different specific notions of equality used in papers. Some effort is required to determine which one is in use.
+
+\subsection{Judgmental Equality}
+
+A natural idea for implementing equality is to specify pairs of terms to be equated directly by judgments, which convey no information other than the equated terms (and, in the type theories we're studying in this course, their type). The equality judgment is written like:
+
+\[
+	\eqterm{\Gamma}{M}{N}{A}
+\]
+
+Judgmental equality is \emph{silent and substitutional}, in the sense that:
+
+\begin{prooftree*}
+	\hypo{\oftype{\Gamma}{M}{A}}
+	\ellipsis{}{\hspace{0.75in}}
+	\hypo{\eqterm{\Gamma}{M}{N}{A}}
+	\ellipsis{}{\hspace{0.75in}}
+	\infer2{\oftype{\Gamma}{N}{A}}
+\end{prooftree*}
+
+This is a useful property if one wants to prove subject reduction (aka type preservation).
+
+However, judgmental equality lacks the ability to be used hypothetically, since judgments cannot be added to the context. To be able to do proofs that require assuming an equality (for example, showing that an assumption leads to a contradiction), we often want a different notion of equality, typically formalized as one of the types described below.
+
+\subsection{Identification Types}
+
+One of the best-known ways for encoding equality as a type is the family of identification types (also called identity types), notated $\idtype{A}{M}{N}$. Intensional Martin-L\"of Type Theory (or Intensional Type Theory) often adopts identification types.
+
+The rules that define them are:
+
+% FIXME(remexre): $\idtype$ doesn't render correctly, and instead renders as {}
+% would. I haven't taken the time to look into this, but when fixed, the
+% \mathtt{Id}s below should be changed.
+\begin{enumerate}
+\item Formation:
+	\begin{prooftree*}
+		\hypo{\istype{A}}
+		\hypo{\oftype{M}{A}}
+		\hypo{\oftype{N}{A}}
+		\infer3[$\mathtt{Id}$-form]{\istype{\idtype{A}{M}{N}}}
+	\end{prooftree*}
+\item Introduction:
+	\begin{prooftree*}
+		\hypo{\oftype{M}{A}}
+		\infer1[$\mathtt{Id}$-intro]{\oftype{\idrefl{M}}{\idtype{A}{M}{M}}}
+	\end{prooftree*}
+\item Elimination:
+	\begin{prooftree*}
+		\hypo{\istype{A}}
+		\hypo{\oftype{N}{A}}
+		\hypo{\oftype{O}{A}}
+		\hypo{\oftype{p}{\idtype{A}{N}{O}}}
+		% FIXME(remexre): blegh... massive hack, since I can't figure
+		% out how to get ebproof to insert newlines...
+		\infer[no rule]4{\istype{x{:}A,y{:}A,q{:}\idtype{A}{x}{y}}{C}}
+		\infer[no rule]1{\oftype{z{:}A}{M}{C[x \rightarrow z, y \rightarrow z, q \rightarrow \idrefl{z}]}}
+		\infer1[$\mathtt{Id}$-elim]{\oftype{\idJ[x][y][q][C]{z}{M}{p}}{C[x \rightarrow N, y \rightarrow O, q \rightarrow p]}}
+	\end{prooftree*}
+\item Computation:
+	\begin{prooftree*}
+		\hypo{\istype{A}}
+		\hypo{\oftype{N}{A}}
+		\hypo{\oftype{O}{A}}
+		% FIXME(remexre): same hack as above... :(
+		\infer[no rule]3{\istype{x{:}A,y{:}A,q{:}\idtype{A}{x}{y}}{C}}
+		\infer[no rule]1{\oftype{z{:}A}{M}{C[x \rightarrow z, y \rightarrow z, q \rightarrow \idrefl{z}]}}
+		\infer1[$\mathtt{Id}$-comp]{\eqterm{\idJ[x][y][q][C]{z}{M}{\idrefl{N}}}{M[z \rightarrow N]}{C[x \rightarrow N, y \rightarrow O, q \rightarrow \idrefl{N}]}}
+	\end{prooftree*}
+\end{enumerate}
+
+The elimination and computation rules here are more complicated than those encountered previously. so some explanation is warranted. These rules state that to prove a statement $C$ containing a term on an identification type $q$, it suffices to consider the case where the term is $\idrefl$. This is justified by the only introduction rule being the reflexive case of equality.
+
+There is also an alternative formulation of $\mathtt{Id}$-elim and $\mathtt{Id}$-comp:
+
+% FIXME(remexre): The hack deepens...
+\begin{prooftree*}
+	\hypo{\istype{A}}
+	\hypo{\oftype{M}{A}}
+	\infer[no rule]2{\oftype{P}{\idtype{A}{M}{M}}}
+	\hypo{\istype{x{:}A,q{:}\idtype{A}{M}{x}}{C}}
+	\infer[no rule]1{\oftype{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
+	\infer2[$\mathtt{Id}$-elim$^{M=}$]{\oftype{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; P}}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
+\end{prooftree*}
+\begin{prooftree*}
+	\hypo{\istype{A}}
+	\hypo{\oftype{M}{A}}
+	\infer[no rule]2{\oftype{P}{\idtype{A}{M}{M}}}
+	\hypo{\istype{x{:}A,q{:}\idtype{A}{M}{x}}{C}}
+	\infer[no rule]1{\oftype{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
+	\infer2[$\mathtt{Id}$-comp$^{M=}$]{\eqterm{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; \idrefl{M}}}{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
+\end{prooftree*}
+
+% NOTE(remexre): The below \cite doesn't render on tectonic; I haven't been
+% able to get it working with pdflatex+biber either, but I'm not enough of
+% a TeX wizard to know what the issue is.
+This formulation is often easier to use in practice, but is equivalent to the one initially presented; see section 1.12.1 of \cite{hott-as:book} for details.
+
+\subsection{(Usual) Equality Types}
+
+Next, we introduce equality types $\mathtt{Eq}_A\parens{M; N}$. They are intended to be a direct internalization of judgmental equality by the following equality reflection rule:
+
+\begin{prooftree*}
+	\hypo{\oftype{\ctx}{p}{\mathtt{Eq}_A\parens{M; N}}}
+	\infer1{\eqterm{\ctx}{M}{N}{A}}
+\end{prooftree*}
+
+Note that by the substitutional nature of judgmental equality the converse holds as well:
+
+\begin{prooftree*}
+	\hypo{\eqterm{\ctx}{M}{N}{A}}
+	\infer1{\oftype{\ctx}{\idrefl{M}}{\mathtt{Eq}_A\parens{M; N}}}
+\end{prooftree*}
+
+In this sense, equality types and judgmental equality are equivalent. Formally, the rules of equality types consist of those of identification types and the equality reflection rule.
+
+\subsection{Reflection-Free Equality Types}
+A variant of equality types is reflection-free equality types. They are intended to obtain the best parts of identification types and (ordinary) equality types. Reflection-free equality types are obtained from equality types by replacing the equality reflection rule by the following strict principle of uniqueness of identity proofs (UIP):
+
+% \begin{mathpar}
+% \AxiomC{$\Gamma \vdash P : \mathsf{Eq}_A(M, N)$}
+% \AxiomC{$\Gamma \vdash Q : \mathsf{Eq}_A(M, N)$}
+% \BinaryInfC{$\Gamma \vdash P \equiv Q : \mathsf{Eq}_A(M, N)$}
+% \DisplayProof
+% \end{mathpar}
+\begin{prooftree*}
+	\hypo{\oftype{\ctx}{p}{\mathtt{Eq}_A\parens{M; N}}}
+	\hypo{\oftype{\ctx}{q}{\mathtt{Eq}_A\parens{M; N}}}
+	\infer2{\eqterm{\ctx}{p}{q}{\mathtt{Eq}_A\parens{M; N}}}
+\end{prooftree*}
+
+That is, UIP states that there is at most one term of a reflection-free equality type.
+Note that the principle is called \emph{strict} because the equality between terms of the same reflection-free equality type in the conclusion is judgmental. 
+
+Alternatively, we may employ Axiom K, which is equivalent to UIP in the sense that one of the two is derivable from the other; see \cite{hott-as:book} for the details. 
+
+\subsection{Identification Types with UIP}
+
+We can also extend identification types with UIP; again see \cite{hott-as:book} for the details. 
+
+\section{The $\omega$-Groupoid Structure of Types}
+
+\begin{theorem}
+Each type $A$ has the structure of an $\omega$-groupoid induced by the identification types constructed from $A$ (recall that a groupoid is a category whose morphisms are all isomorphisms, and an $\omega$-groupoid is an ``infinite-dimensional generalization'' of a groupoid).
+\end{theorem}
+
+This theorem discovers a new connection between type theory and higher category theory. Note, however, that the theorem does not hold if identification types are substituted by equality types or reflection-free equality types introduced below; this is one of the main reasons why identification types are the most popular choice among types on equality.
+
+The homotopy-theoretic point of view on type theory, which creates the currently active field of homotopy type theory, interprets:
+
+\begin{itemize}
+\item Types as certain \emph{topological spaces};
+\item Elements as \emph{points} in a topological space;
+\item Functions as continuous maps between topological spaces;
+\item Terms of identification types as \emph{paths} between points. 
+\end{itemize}
+
+We can justify the rules of identification types by the homotopy-theoretic interpretation because any path can be continuously transformed into a trivial path or reflexivity.
+
+\printbibliography
+
+\end{document}

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -141,11 +141,9 @@ A variant of equality types is reflection-free equality types \cite{sterling_et_
 That is, UIP states that there is at most one term of a reflection-free equality type.
 Note that the principle is called \emph{strict} because the equality between terms of the same reflection-free equality type in the conclusion is judgmental. 
 
-Alternatively, we may employ Axiom K, which is equivalent to UIP in the sense that one of the two is derivable from the other; see \cite{hott-as:book} for the details. 
-
 \subsection{Identification Types with UIP}
 
-We can also extend identification types with UIP; again see \cite{hott-as:book} for the details. 
+We can also extend identification types with UIP, or alternatively Axiom K. Axiom K is equivalent to UIP in the sense that either of the two is derivable from the other; see section 7.2 of \cite{hott-as:book} for the details. 
 
 \section{The $\infty$-Groupoid Structure of Types}
 

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -52,21 +52,18 @@ One of the best-known ways for encoding equality as a type is the family of iden
 
 The rules that define them are:
 
-% FIXME(remexre): $\idtype$ doesn't render correctly, and instead renders as {}
-% would. I haven't taken the time to look into this, but when fixed, the
-% \mathtt{Id}s below should be changed.
 \begin{enumerate}
 \item Formation:
 	\begin{prooftree*}
 		\hypo{\istype{A}}
 		\hypo{\oftype{M}{A}}
 		\hypo{\oftype{N}{A}}
-		\infer3[$\mathtt{Id}$-form]{\istype{\idtype{A}{M}{N}}}
+		\infer3[$\idtype$-form]{\istype{\idtype{A}{M}{N}}}
 	\end{prooftree*}
 \item Introduction:
 	\begin{prooftree*}
 		\hypo{\oftype{M}{A}}
-		\infer1[$\mathtt{Id}$-intro]{\oftype{\idrefl{M}}{\idtype{A}{M}{M}}}
+		\infer1[$\idtype$-intro]{\oftype{\idrefl{M}}{\idtype{A}{M}{M}}}
 	\end{prooftree*}
 \item Elimination:
 	\begin{prooftree*}
@@ -78,7 +75,7 @@ The rules that define them are:
 		% out how to get ebproof to insert newlines...
 		\infer[no rule]4{\istype{x{:}A,y{:}A,q{:}\idtype{A}{x}{y}}{C}}
 		\infer[no rule]1{\oftype{z{:}A}{M}{C[x \rightarrow z, y \rightarrow z, q \rightarrow \idrefl{z}]}}
-		\infer1[$\mathtt{Id}$-elim]{\oftype{\idJ[x][y][q][C]{z}{M}{p}}{C[x \rightarrow N, y \rightarrow O, q \rightarrow p]}}
+		\infer1[$\idtype$-elim]{\oftype{\idJ[x][y][q][C]{z}{M}{p}}{C[x \rightarrow N, y \rightarrow O, q \rightarrow p]}}
 	\end{prooftree*}
 \item Computation:
 	\begin{prooftree*}
@@ -88,13 +85,13 @@ The rules that define them are:
 		% FIXME(remexre): same hack as above... :(
 		\infer[no rule]3{\istype{x{:}A,y{:}A,q{:}\idtype{A}{x}{y}}{C}}
 		\infer[no rule]1{\oftype{z{:}A}{M}{C[x \rightarrow z, y \rightarrow z, q \rightarrow \idrefl{z}]}}
-		\infer1[$\mathtt{Id}$-comp]{\eqterm{\idJ[x][y][q][C]{z}{M}{\idrefl{N}}}{M[z \rightarrow N]}{C[x \rightarrow N, y \rightarrow O, q \rightarrow \idrefl{N}]}}
+		\infer1[$\idtype$-comp]{\eqterm{\idJ[x][y][q][C]{z}{M}{\idrefl{N}}}{M[z \rightarrow N]}{C[x \rightarrow N, y \rightarrow O, q \rightarrow \idrefl{N}]}}
 	\end{prooftree*}
 \end{enumerate}
 
 The elimination and computation rules here are more complicated than those encountered previously. so some explanation is warranted. These rules state that to prove a statement $C$ containing a term on an identification type $q$, it suffices to consider the case where the term is $\idrefl$. This is justified by the only introduction rule being the reflexive case of equality.
 
-There is also an alternative formulation of $\mathtt{Id}$-elim and $\mathtt{Id}$-comp:
+There is also an alternative formulation of $\idtype$-elim and $\idtype$-comp:
 
 % FIXME(remexre): The hack deepens...
 \begin{prooftree*}
@@ -103,7 +100,7 @@ There is also an alternative formulation of $\mathtt{Id}$-elim and $\mathtt{Id}$
 	\infer[no rule]2{\oftype{P}{\idtype{A}{M}{M}}}
 	\hypo{\istype{x{:}A,q{:}\idtype{A}{M}{x}}{C}}
 	\infer[no rule]1{\oftype{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
-	\infer2[$\mathtt{Id}$-elim$^{M=}$]{\oftype{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; P}}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
+	\infer2[$\idtype$-elim$^{M=}$]{\oftype{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; P}}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
 \end{prooftree*}
 \begin{prooftree*}
 	\hypo{\istype{A}}
@@ -111,7 +108,7 @@ There is also an alternative formulation of $\mathtt{Id}$-elim and $\mathtt{Id}$
 	\infer[no rule]2{\oftype{P}{\idtype{A}{M}{M}}}
 	\hypo{\istype{x{:}A,q{:}\idtype{A}{M}{x}}{C}}
 	\infer[no rule]1{\oftype{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
-	\infer2[$\mathtt{Id}$-comp$^{M=}$]{\eqterm{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; \idrefl{M}}}{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
+	\infer2[$\idtype$-comp$^{M=}$]{\eqterm{\mathtt{J}^{M=}\brackets{x.q.C}\parens{N; \idrefl{M}}}{N}{C[x \rightarrow M, q \rightarrow \idrefl{M}]}}
 \end{prooftree*}
 
 % NOTE(remexre): The below \cite doesn't render on tectonic; I haven't been

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -127,9 +127,8 @@ Note that by the substitutional nature of judgmental equality the converse holds
 	\infer1{\oftype{\ctx}{\idrefl{M}}{\mathtt{Eq}_A\parens{M; N}}}
 \end{prooftree*}
 
-In this sense, equality types and judgmental equality are equivalent. Formally, the rules of equality types consist of those of identification types and the equality reflection rule.
+In this sense, equality types and judgmental equality are equivalent. Formally, the rules of equality types consist of those of identification types, the equality reflection rule, and the following uniqueness rule:
 
-Note: One implementation of equality types additionally has the following uniqueness rule:
 \begin{prooftree*}
 	\hypo{\oftype{p}{\mathtt{Eq}_A\parens{M; N}}}
 	\infer1[$\mathtt{Eq}$-uniq]{\eqterm{p}{\idrefl}{\mathtt{Eq}_A\parens{M; N}}}

--- a/notes-20200211.tex
+++ b/notes-20200211.tex
@@ -16,7 +16,7 @@ Two commonly used but insufficiently precise terms used to dicuss notions of equ
 
 An extensional notion of equality treats two objects that have observationally equivalent properties as being equal. For example, one might consider the sets $A = \left(\{\textrm{single-digit primes}\} \cup \{6\}\right)$ to be extensionally equal to $B = \left(\{\textrm{single-digit numbers}\} - \{x^2 \mid x \in \mathbb{N}\}\right)$, since $\forall n. \left(n \in A \iff n \in B\right)$. Similarly, $x + y$ and $y + x$ would be considered equal, since their results are the same for any $x$ and $y$.
 
-Contrastingly, an intensional notion of equality only considers objects to be equal if their definitions are equal. Often the equality of definitions is checked syntactically; i.e., two definitions are equivalent if and only if they are literally textually identical. With such a definition, neither $A$ and $B$ nor $x + y$ and $y + x$ would \textbf{not} be considered equal,
+Contrastingly, an intensional notion of equality only considers objects to be equal if their definitions are equal. Often the equality of definitions is checked syntactically; i.e., two definitions are equivalent if and only if they are literally textually identical. With such a definition, neither $A$ and $B$ nor $x + y$ and $y + x$ would \textbf{not} be considered equal.
 
 Theories built on the lambda calculus that claim to use intensional equality will often define this syntactic equality to be after $\alpha$, $\beta$, and $\eta$-normalization. This makes the terms $\lam{x}[\nattype]{x}$ and $\app{\parens{\lam{p}[\funtype{\nattype}{\nattype}]{p}}}{\parens{\lam{q}[\nattype]{q}}}$ equal, and is often useful, since the evaluation rules don't need to be manipulated by the user.
 

--- a/references.bib
+++ b/references.bib
@@ -16,3 +16,22 @@
   addendum={Page numbers are based on the online free version},
   address={Cambridge, UK}
 }
+
+@InProceedings{sterling_et_al:LIPIcs:2019:10538,
+  author =	{Jonathan Sterling and Carlo Angiuli and Daniel Gratzer},
+  title =	{{Cubical Syntax for Reflection-Free Extensional Equality}},
+  booktitle =	{4th International Conference on Formal Structures for Computation and Deduction (FSCD 2019)},
+  pages =	{31:1--31:25},
+  series =	{Leibniz International Proceedings in Informatics (LIPIcs)},
+  ISBN =	{978-3-95977-107-8},
+  ISSN =	{1868-8969},
+  year =	{2019},
+  volume =	{131},
+  editor =	{Herman Geuvers},
+  publisher =	{Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
+  address =	{Dagstuhl, Germany},
+  URL =		{http://drops.dagstuhl.de/opus/volltexte/2019/10538},
+  URN =		{urn:nbn:de:0030-drops-105387},
+  doi =		{10.4230/LIPIcs.FSCD.2019.31},
+  annote =	{Keywords: Dependent type theory, extensional equality, cubical type theory, categorical gluing, canonicity}
+}

--- a/references.bib
+++ b/references.bib
@@ -30,7 +30,6 @@
   editor =	{Herman Geuvers},
   publisher =	{Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
   address =	{Dagstuhl, Germany},
-  URL =		{http://drops.dagstuhl.de/opus/volltexte/2019/10538},
   URN =		{urn:nbn:de:0030-drops-105387},
   doi =		{10.4230/LIPIcs.FSCD.2019.31},
   annote =	{Keywords: Dependent type theory, extensional equality, cubical type theory, categorical gluing, canonicity}


### PR DESCRIPTION
Still has a few "code cleanliness" `FIXME`s:

- [x] `$\idtype$` doesn't render correctly (https://github.com/remexre/hdtt2020-notes/blob/master/notes-20200211.tex#L55-L57)
- [ ] massive hack since I can't get ebproof to insert newlines (https://github.com/remexre/hdtt2020-notes/blob/master/notes-20200211.tex#L77-L78)
- [x] `\cite` isn't working on my machine with hdtt2020.sty (and possibly in general), so the citations may be arbitrarily wrong (https://github.com/remexre/hdtt2020-notes/blob/master/notes-20200211.tex#L117-L119)

But content-wise, should be OK to merge.

Since it hasn't been merged yet, I'll state that I'm OK with the license in #9; Nori should be checked with though.